### PR TITLE
Update wording, remove .dev references

### DIFF
--- a/02-Introduction-to-GitHub-Codespaces/README.md
+++ b/02-Introduction-to-GitHub-Codespaces/README.md
@@ -4,7 +4,7 @@
 
 Welcome to the exciting world of GitHub Codespaces, your cloud based coding resource. In this module, we'll delve into the realm of instant, cloud-based development environments, revolutionizing the way you approach coding. GitHub Codespaces provides a seamlessly integrated experience, offering a container equipped with the essential languages, tools, and utilities for development.
 
-Throughout this learning journey, we will embark on a discovery of the Codespaces lifecycle and processes. Uncover the power to tailor your Codespace setup to suit your unique preferences and requirements. Engage in a comparative analysis of GitHub Codespaces and GitHub.dev, gaining insights into the distinctions between these innovative platforms. To solidify your understanding, we'll cap off the module with a hands-on exercise, allowing you to flex your coding muscles within the GitHub Codespaces environment.
+Throughout this learning journey, we will embark on a discovery of the Codespaces lifecycle and processes. Uncover the power to tailor your Codespace setup to suit your unique preferences and requirements. To solidify your understanding, we'll cap off the module with a hands-on exercise, allowing you to flex your coding muscles within the GitHub Codespaces environment.
 
 Imagine a fully configured development environment at your fingertips, accessible from any computer with an internet connection. GitHub Codespaces opens the door to a new era of collaborative and flexible coding. Let's dive in and unlock the full potential of cloud-based development with GitHub Codespaces!
 
@@ -24,7 +24,6 @@ By the end of this module, you'll be able to:
 1. Describe GitHub Codespaces.
 2. Explain the GitHub Codespace lifecycle and how to perform each step.
 3. Define the different customizations you can personalize with GitHub Codespaces.
-4. Discern the differences between GitHub.dev and GitHub Codespaces.
 
 
 ## Prerequisite reading: 

--- a/03-Introduction-to-GitHub-Copilot/README.md
+++ b/03-Introduction-to-GitHub-Copilot/README.md
@@ -4,12 +4,14 @@
 
 In this learning module, we'll dive into the revolutionary landscape of AI-pair programming with GitHub Copilot, the first-ever at-scale AI developer tool designed to enhance your coding experience.
 
-GitHub Copilot, powered by OpenAI Codex, analyzes context from comments and code to provide autocomplete-style suggestions, enabling you to write code faster and with less effort. As you delve into this module, you'll unravel the intricacies of GitHub Copilot, exploring its capabilities within VS Code and Codespaces.
+GitHub Copilot analyzes context from files and comments and input from its interactive chat to provide autocomplete-style suggestions, enabling you to write code faster and with less effort. As you delve into this module, you'll unravel the intricacies of GitHub Copilot, exploring its capabilities within VS Code and Codespaces.
 
-Our learning objectives are ambitious yet achievable. By the module's conclusion, you will not only be able to articulate what GitHub Copilot is and its advantages but also comprehend its availability for individuals and businesses. Gain insights into the future of GitHub Copilot with Copilot X, and dive into hands-on exercises to master its utilization with Visual Studio Code.
+Our learning objectives are ambitious yet achievable. By the module's conclusion, you will not only be able to articulate what GitHub Copilot is and its advantages but also comprehend its availability for individuals and businesses. Gain insights into the future of GitHub Copilot, and dive into hands-on exercises to master its utilization with Visual Studio Code.
 
 As research has shown, GitHub Copilot empowers developers to code faster, focus on solving substantial problems, maintain longer periods of productivity, and experience greater fulfillment in their work.
 
+
+Note: Although this module uses [Codespaces](https://github.com/codespaces), you can use GitHub Copilot in a variety of other environments, including locally with Visual Studio Code.
 </header>
 
 
@@ -24,7 +26,7 @@ By the end of this module, you'll be able to:
 
 - Explain what GitHub Copilot is and the advantages it provides.
 - Understand the availability of GitHub Copilot for individuals and Businesses.
-- Discuss the future of GitHub Copilot with Copilot X.
+- Discuss the future of GitHub Copilot.
 - Learn how to get started using GitHub Copilot and some common configurations.
 - Develop using GitHub Copilot with Visual Studio Code using hands-on exercises.
 


### PR DESCRIPTION
This PR removes references to Copilot X, GitHub.dev, and highlights that one can use GitHub Copilot with Visual Studio Code locally in addition to using Codespaces.