### PR TITLE
Update README.md

### DIFF
--- a/03-Introduction-to-GitHub-Copilot/README.md
+++ b/03-Introduction-to-GitHub-Copilot/README.md
@@ -49,7 +49,7 @@ By the end of this module, you'll be able to:
 }).toString()
 -->
 
-[![start-course](https://user-images.githubusercontent.com/1221423/235727646-4a590299-ffe5-480d-8cd5-8194ea184546.svg)](https://github.com/new?template_owner=skills&template_name=copilot-codespaces-vscode&owner=%40me&name=skills-copilot-codespaces-vscode&description=My+clone+repository&visibility=public)
+[![start-course](https://github.com/new?template_owner=skills&template_name=getting-started-with-github-copilot&owner=@me&name=skills-getting-started-with-github-copilot&description=Exercise:+Get+started+using+GitHub+Copilot&visibility=public)
 
 1. Right-click **Start course** and open the link in a new tab.
 2. In the new tab, most of the prompts will automatically fill in for you.


### PR DESCRIPTION
This pull request updates the "Start course" link in the `03-Introduction-to-GitHub-Copilot/README.md` file to point to a new course template.

* Updated the "Start course" link to use the `getting-started-with-github-copilot` template instead of the `copilot-codespaces-vscode` template.