### PR TITLE
Fixing link for into to co-pilot template

### DIFF
--- a/03-Introduction-to-GitHub-Copilot/README.md
+++ b/03-Introduction-to-GitHub-Copilot/README.md
@@ -41,15 +41,15 @@ By the end of this module, you'll be able to:
 <!-- For start course, run in JavaScript:
 'https://github.com/new?' + new URLSearchParams({
   template_owner: 'skills',
-  template_name: 'copilot-codespaces-vscode',
+  template_name: 'getting-started-with-github-copilot',
   owner: '@me',
-  name: 'skills-copilot-codespaces-vscode',
+  name: 'skills-getting-started-with-github-copilot',
   description: 'My clone repository',
   visibility: 'public',
 }).toString()
 -->
 
-[![start-course](https://user-images.githubusercontent.com/1221423/235727646-4a590299-ffe5-480d-8cd5-8194ea184546.svg)](https://github.com/new?template_owner=skills&template_name=copilot-codespaces-vscode&owner=%40me&name=skills-copilot-codespaces-vscode&description=My+clone+repository&visibility=public)
+[![start-course](https://user-images.githubusercontent.com/1221423/235727646-4a590299-ffe5-480d-8cd5-8194ea184546.svg)](https://github.com/new?template_owner=skills&template_name=getting-started-with-github-copilot&owner=%40me&name=getting-started-with-github-copilot&description=My+clone+repository&visibility=public)
 
 1. Right-click **Start course** and open the link in a new tab.
 2. In the new tab, most of the prompts will automatically fill in for you.


### PR DESCRIPTION
Upon reviewing the [03-Introduction-to-GitHub-Copilot](https://github.com/microsoft/Mastering-GitHub-Copilot-for-Paired-Programming/tree/main/03-Introduction-to-GitHub-Copilot) course. The link to start the course appears to be referencing a template that no longer exists. [Searching through the templates](https://github.com/orgs/skills/repositories?q=template%3Atrue+archived%3Afalse+copilot) I _think_ the correct template is the [getting-started-with-github-copilot](https://github.com/skills/getting-started-with-github-copilot) template. This PR adjust the relevant links and data to point to that.