### PR TITLE
Fix documentation typos

### DIFF
--- a/Using-GitHub-Copilot-CLI/4-Customization-and-Extensions.md
+++ b/Using-GitHub-Copilot-CLI/4-Customization-and-Extensions.md
@@ -4,7 +4,7 @@
 
 ---
 
-### 🗒️ Section 6: Context Optimzation with Copilot: Custom Agents, Custom Instructions, and MCP Integrations
+### 🗒️ Section 6: Context Optimization with Copilot: Custom Agents, Custom Instructions, and MCP Integrations
 
 🎯 **Learning Goals**
 - Understand custom agents and how to configure them for specialised tasks

--- a/Using-GitHub-Copilot-Coding-Agent/1-Assigning-and-Tracking.md
+++ b/Using-GitHub-Copilot-Coding-Agent/1-Assigning-and-Tracking.md
@@ -41,7 +41,7 @@ This is distinct from **agent mode in your IDE**, which edits your local files i
 3. On the issue page, click **Assignees** and select **Copilot** from the assignee list.
 
    > Copilot will begin working immediately. You'll see the issue label update to indicate an agent session is in progress.
-<img width="500" alt="Assigment panel for issue showing Copilot is selected and the name has an AI badge next to it." src="https://github.com/user-attachments/assets/dec2f4af-c606-4350-9911-ee109c64cf36" />
+<img width="500" alt="Assignment panel for issue showing Copilot is selected and the name has an AI badge next to it." src="https://github.com/user-attachments/assets/dec2f4af-c606-4350-9911-ee109c64cf36" />
 
 1. Observe that Copilot creates a new branch named `copilot/<issue-number>-<slug>` and begins opening commits.
 


### PR DESCRIPTION
Fix two documentation typos: change Optimzation to Optimization and Assigment to Assignment in the Copilot CLI and coding agent lessons.